### PR TITLE
Minor export fix & rename mistyped file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 
 image.*
 postimage.png
+
+package-lock.json

--- a/credentials.ts
+++ b/credentials.ts
@@ -10,4 +10,4 @@ const credentials: Credentials = {
   password: process.env.PASSWORD,
 };
 
-export { credentials };
+export = credentials;

--- a/instaAutomation.ts
+++ b/instaAutomation.ts
@@ -1,7 +1,7 @@
 const puppeteer = require('puppeteer');
 
 const config = require('./config');
-const credentials = require('./credetials');
+const credentials = require('./credentials');
 
 const USERNAME_SELECTOR: string = '[name="username"]';
 const PASSWORD_SELECTOR: string = '[name="password"]';


### PR DESCRIPTION
- Renamed `credetials.ts` into `credentials.ts`
- Fixed the way credentials are exported, since the previous way was yielding `{ credentials: { username: 'hi', password: 'there' } }` instead of expected `{ username: 'hi', password: 'there' }`, causing an exception in instaAutomation.ts
- ignoring `package-lock.json` in git